### PR TITLE
Fix NumPy 2.0 compatibility: use .item() for array-to-scalar conversion

### DIFF
--- a/aragog/mesh.py
+++ b/aragog/mesh.py
@@ -448,7 +448,7 @@ class Mesh:
         return quantity_at_staggered_nodes
 
     def volume_average(self, staggered_quantity: npt.NDArray) -> float:
-        return float(np.dot(staggered_quantity.T, self.basic.volume)) / self.basic.total_volume
+        return np.dot(staggered_quantity.T, self.basic.volume).item() / self.basic.total_volume
 
 
 class EOS(ABC):


### PR DESCRIPTION
This pull request makes a minor adjustment to the `volume_average` method in `aragog/mesh.py` to improve type consistency when calculating the average. This is needed for the test_coverage changes in PROTEUS.

* Changed the return expression in the `volume_average` method to use `.item()` instead of `float()` for extracting the scalar value from the dot product result, ensuring more robust handling of NumPy scalar types.