### PR TITLE
Add nightly.yml workflow stub for branch dispatch

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,58 @@
+name: Aragog nightly
+
+on:
+  schedule:
+    # 02:30 UTC daily (offset from Zalmoxis 02:00 UTC to spread runner load).
+    - cron: "30 2 * * *"
+  # Manual trigger for ad-hoc runs (e.g. before cutting a release, or to
+  # verify the suite on a feature branch via
+  # `gh workflow run "Aragog nightly" -r <branch>`).
+  workflow_dispatch:
+
+# Least-privilege token: only read access to the repo contents. Coverage
+# upload uses the CODECOV_TOKEN secret directly, not the default
+# GITHUB_TOKEN.
+permissions:
+  contents: read
+
+# Nightly: full unit + slow suite with coverage instrumentation and the
+# 85% floor enforced via [tool.coverage.report].fail_under in pyproject.toml.
+# Excluded from push and PR CI because the slow tier alone takes ~110 s and
+# coverage instrumentation pushes the full run to ~10 min on a 2-vCPU
+# runner, over the 5 min budget for fast CI.
+jobs:
+  nightly:
+    name: Aragog-nightly (ubuntu-latest)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pytest pytest-cov pytest-xdist pytest-dependency
+
+      - name: Run unit + slow tests with coverage
+        run: |
+          pytest -m "unit or slow" -o "addopts=" \
+            --cov=src/aragog --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: FormingWorlds/Aragog
+          files: coverage.xml
+          flags: nightly
+          fail_ci_if_error: false


### PR DESCRIPTION
## Description

Land the `nightly.yml` workflow file on main so it becomes dispatchable on feature branches via `gh workflow run`. GitHub's `workflow_dispatch` API gates on default-branch presence; a workflow that lives only on a feature branch returns 404.

The downstream goal: trigger the Aragog nightly suite (full unit + slow tests with coverage instrumentation and Codecov upload) on PR #12's `tl/interior-refactor` branch before squash-merging it, so we have a coverage number to gate the merge on.

## Validation of changes

- Workflow content is identical to what already exists on `tl/interior-refactor` (PR #12 commit `fdb4bf6`), so the upcoming squash-merge of #12 will not conflict on this path.
- The cron schedule `30 2 * * *` UTC (04:30 CET) is included. If it fires on main between this PR merging and PR #12 merging, the run will fail because main lacks the `src/aragog/` source layout, the `slow` marker registration, and the coverage config that #12 brings. One transient failure is acceptable; same approach as the Zalmoxis bootstrap from 2026-05-06.

## Changes

- Add `.github/workflows/nightly.yml` (58 lines).

## Testing

- [x] File content matches `tl/interior-refactor:.github/workflows/nightly.yml` byte-for-byte (no merge conflict on PR #12 squash).
- [ ] After this PR merges, `gh workflow run "Aragog nightly" -r tl/interior-refactor -R FormingWorlds/aragog` returns 0 instead of 404.