### PR TITLE
Release 26.05.10

### DIFF
--- a/docs/Reference/cli.md
+++ b/docs/Reference/cli.md
@@ -7,7 +7,7 @@ PROTEUS-coupled runs do *not* use the CLI; the `proteus` driver builds `Paramete
 ## Group flags
 
 ```
-aragog --version    # bare aragog version, e.g. 'aragog 26.05.08'
+aragog --version    # bare aragog version, e.g. 'aragog 26.05.10'
 aragog --versions   # multi-line block: aragog + numpy / scipy / jax / scikits.odes / netCDF4
 ```
 
@@ -147,7 +147,7 @@ Default output is human-readable: scalar lines aligned in two columns with units
 
 ```
 snapshot: out.nc
-  aragog: 26.05.08
+  aragog: 26.05.10
   created: 2026-05-09T00:00:00+00:00
   description: Aragog run from earth_smoke.toml
   dimensions: staggered=120, basic=121

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fwl-aragog"
-version = "26.05.08"
+version = "26.05.10"
 description = "1-D interior dynamics of rocky mantles that are solid, liquid, or mixed phase"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/aragog/__init__.py
+++ b/src/aragog/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-__version__: str = '26.05.08'
+__version__: str = '26.05.10'
 
 import importlib.resources
 import logging


### PR DESCRIPTION
## What this does

Bumps the package version from `26.05.08` to `26.05.10` so the next release tag matches today's date. Touches three files: `pyproject.toml` (`version`), `src/aragog/__init__.py` (`__version__`), and the two example strings in `docs/Reference/cli.md`.

## Why

The originally-planned merge date for PR #12 (the P-S production refactor) was `26.05.08`; the PR actually merged today, `2026-05-10`. Tagging the release as `26.05.10` (matching the merge date, per the Zalmoxis precedent of PR #59 → release `26.05.06`) is the convention. This PR aligns the in-tree metadata with the tag that follows.

## Changes

- `pyproject.toml`: `version = "26.05.10"`
- `src/aragog/__init__.py`: `__version__: str = '26.05.10'`
- `docs/Reference/cli.md`: example version strings in the `--version` and `inspect` blocks bumped to `26.05.10`

## Testing

- `grep -rE "26\.05\.08"` confirms no stale references remain on this branch
- Push CI runs the unit tier (already covered by the standard `ci_tests.yml` matrix)
- The release tag `26.05.10` will be created on `main` after this PR merges; `publish.yaml` triggers PyPI upload automatically via Trusted Publishing