### PR TITLE
Document the melt-solid mobility across the three Abe regimes

### DIFF
--- a/docs/Explanations/heat_transport.md
+++ b/docs/Explanations/heat_transport.md
@@ -45,7 +45,7 @@ $$
 w = \tfrac{1}{2}\Big[1 + \tanh\!\big((\mathrm{Re} - Re_\mathrm{crit})/\Delta\big)\Big],
 $$
 
-with $\mathrm{Re} = v_\mathrm{visc}\,l / \nu$, $Re_\mathrm{crit} = 9/8$, and a narrow blend width $\Delta = 0.01\,Re_\mathrm{crit}$. The narrow blend keeps inviscid mixing confined to the convecting regime; widening it leaks inviscid $\kappa_h$ into the solid phase and induces $T_\mathrm{core}$ bistability.
+with $\mathrm{Re} = v_\mathrm{visc}\,l / \nu$ and a narrow blend width $\Delta = 0.01\,Re_\mathrm{crit}$. The critical Reynolds number $Re_\mathrm{crit} = 9/8$ that Aragog inherits comes via Abe (1995)[^cite-abe1995] and is documented in Bower et al. (2018)[^cite-bower2018] §2.1. The narrow blend keeps inviscid mixing confined to the convecting regime; widening it leaks inviscid $\kappa_h$ into the solid phase and induces $T_\mathrm{core}$ bistability.
 
 ### Mixing length profile
 
@@ -89,7 +89,7 @@ where $L(P)$ is the EOS-tabulated, pressure-dependent latent heat of fusion.
 ### Melt-solid mobility across the three Abe regimes
 
 The factor that sets the relative velocity, $v_\mathrm{rel} = F(\zeta)\,(\rho_m-\rho_s)\,g/\eta_m$, is the melt-solid mobility $F(\zeta)$: the permeability $K(\zeta)$ divided by the porosity $\zeta$ (the melt volume fraction, $\zeta \equiv \phi$).
-Following Abe (1993)[^cite-abe1993], with $a$ the grain size set by `grain_size`, its three regimes are
+Following Abe (1995)[^cite-abe1995] and Bower et al. (2018)[^cite-bower2018] §2.1, with $a$ the grain size set by `grain_size`, its three regimes are
 
 $$
 F(\zeta) = \frac{K(\zeta)}{\zeta} = a^2
@@ -106,7 +106,7 @@ Figure 1 plots the dimensionless mobility $F(\zeta)/a^2$: the three individual b
 
 ![Melt-solid mobility F(porosity)](../figures/vv/fig_04_permeability.png)
 
-**Figure 1.** The gravitational-separation mobility $F(\zeta) = K(\zeta)/\zeta$ (the permeability divided by porosity), shown as the dimensionless $F(\zeta)/a^2$ against porosity. Dashed lines: the three regime branches considered individually, namely Blake-Kozeny-Carman (BKC), Rumpf-Gupte (RG), and Stokes settling, following Abe (1993)[^cite-abe1993]. Solid black: the smooth tanh-blended composite that Aragog actually evaluates, with regime-switch porosities $\zeta_1=0.0769452$ (BKC to RG) and $\zeta_2=0.771462$ (RG to Stokes). (a) Linear axis showing the smooth crossover. (b) Log-log axis showing the BKC regime extending to vanishingly small porosity. The numpy and JAX implementations agree to within float-64 machine epsilon ($\max|\Delta F|=1.1\times 10^{-16}$ in absolute units).
+**Figure 1.** The gravitational-separation mobility $F(\zeta) = K(\zeta)/\zeta$ (the permeability divided by porosity), shown as the dimensionless $F(\zeta)/a^2$ against porosity. Dashed lines: the three regime branches considered individually, namely Blake-Kozeny-Carman (BKC), Rumpf-Gupte (RG), and Stokes settling, following Abe (1995)[^cite-abe1995] and Bower et al. (2018)[^cite-bower2018] §2.1. Solid black: the smooth tanh-blended composite that Aragog actually evaluates, with regime-switch porosities $\zeta_1=0.0769452$ (BKC to RG) and $\zeta_2=0.771462$ (RG to Stokes). (a) Linear axis showing the smooth crossover. (b) Log-log axis showing the BKC regime extending to vanishingly small porosity. The numpy and JAX implementations agree to within float-64 machine epsilon ($\max|\Delta F|=1.1\times 10^{-16}$ in absolute units).
 
 ### Phase-boundary smoothing
 
@@ -172,4 +172,5 @@ Per-staggered-node heating is in `heating` (sum of the two contributions); per-c
 **Figure 2.** (a) Magnitude of the four heat-flux components $F_\text{cond}$, $F_\text{conv}$, $F_\text{grav}$, $F_\text{mix}$ and their sum on an 80-cell Earth mesh, evaluated at a fully-mushy state where the entropy on each cell is the midpoint of the local solidus and liquidus values plus a small surface-ward gradient. Open triangles mark cells where the signed flux is negative. The four components reconstruct $F_\text{tot}$ to floating-point round-off ($\max|F_\text{tot}-\sum F_i|/|F_\text{tot}| < 10^{-15}$). (b) Internal volumetric heating sources $H_\text{radio}$, $H_\text{tidal}$ at the staggered nodes for the same state, with the bundled radionuclide cocktail at $t=0$.
 
 [^cite-abe1993]: Yutaka Abe, *[Thermal evolution and chemical differentiation of the terrestrial magma ocean](https://doi.org/10.1029/GM074p0041)*, Geophysical Monograph 74, AGU, 41–54, 1993. [SciX](https://scixplorer.org/abs/1993GMS....74...41A/abstract).
+[^cite-abe1995]: Yutaka Abe, *Basic equations for evolution of partially molten mantle and core*, in Yukutake, T. (ed.), The Earth's Central Part: Its Structure and Dynamics, Terra Sci. Pub. Com., 215–230, 1995.
 [^cite-bower2018]: D. J. Bower, P. Sanan, A. S. Wolf, *[Numerical solution of a non-linear conservation law applicable to the interior dynamics of partially molten planets](https://doi.org/10.1016/j.pepi.2017.11.004)*, Physics of the Earth and Planetary Interiors, 274, 49–62, 2018. [SciX](https://scixplorer.org/abs/2018PEPI..274...49B/abstract).

--- a/docs/Explanations/heat_transport.md
+++ b/docs/Explanations/heat_transport.md
@@ -88,6 +88,21 @@ where $L(P)$ is the EOS-tabulated, pressure-dependent latent heat of fusion.
 
 ### Permeability $K(\zeta)$ across the three Abe regimes
 
+The permeability is a piecewise function of the porosity $\zeta$ (the melt volume fraction that enters $K$), with $a$ the grain size set by `grain_size`.
+Following Abe (1993)[^cite-abe1993], the three regimes are
+
+$$
+K(\zeta) = a^2
+\begin{cases}
+\dfrac{2}{9} & \zeta > 0.771462 \quad\text{(Stokes settling)} \\[2mm]
+\dfrac{5}{7}\,\zeta^{4.5} & 0.0769452 \le \zeta \le 0.771462 \quad\text{(Rumpf-Gupte)} \\[2mm]
+10^{-3}\,\dfrac{\zeta^2}{(1-\zeta)^2} & \zeta < 0.0769452 \quad\text{(Blake-Kozeny-Carman)}
+\end{cases}
+$$
+
+Aragog evaluates a $\tanh$-blended composite of these three branches rather than the hard piecewise switch, so that $K(\zeta)$ and its porosity derivative stay continuous for the JAX Jacobian.
+Figure 1 plots the dimensionless factor $F(\zeta) = K(\zeta)/a^2$: the three individual branches (dashed) and the blended composite that Aragog actually evaluates (solid).
+
 ![Permeability F(porosity)](../figures/vv/fig_04_permeability.png)
 
 **Figure 1.** The gravitational-separation permeability factor $F(\zeta) = K(\zeta)/a^2$ as a function of porosity. Dashed lines: the three regime branches considered individually, namely Blake-Kozeny-Carman (BKC), Rumpf-Gupte (RG), and Stokes settling, following Abe (1993)[^cite-abe1993]. Solid black: the smooth tanh-blended composite that Aragog actually evaluates, with regime-switch porosities $\zeta_1=0.0769452$ (BKC to RG) and $\zeta_2=0.771462$ (RG to Stokes). (a) Linear axis showing the smooth crossover. (b) Log-log axis showing the BKC regime extending to vanishingly small porosity. The numpy and JAX implementations agree to within float-64 machine epsilon ($\max|\Delta F|=1.1\times 10^{-16}$ in absolute units).

--- a/docs/Explanations/heat_transport.md
+++ b/docs/Explanations/heat_transport.md
@@ -75,10 +75,10 @@ In the partially molten regime, melt and solid separate vertically by gravity. T
 
 $$
 j_\mathrm{grav} = \rho\,\phi(1-\phi)\,v_\mathrm{rel}\,\mathrm{smth}(\phi),\qquad
-v_\mathrm{rel} = \frac{(\rho_m - \rho_s)\,g\,K(\phi)}{\eta_m},
+v_\mathrm{rel} = \frac{(\rho_m - \rho_s)\,g\,F(\phi)}{\eta_m},
 $$
 
-with $K(\phi)$ a Stokes-or-Darcy permeability and $\eta_m$ the melt viscosity. The corresponding heat flux is
+with $F(\phi)$ the melt-solid mobility (the permeability over porosity, detailed below) and $\eta_m$ the melt viscosity. The corresponding heat flux is
 
 $$
 F_\mathrm{grav} = j_\mathrm{grav}\,L(P),
@@ -86,13 +86,13 @@ $$
 
 where $L(P)$ is the EOS-tabulated, pressure-dependent latent heat of fusion.
 
-### Permeability $K(\zeta)$ across the three Abe regimes
+### Melt-solid mobility across the three Abe regimes
 
-The permeability is a piecewise function of the porosity $\zeta$ (the melt volume fraction that enters $K$), with $a$ the grain size set by `grain_size`.
-Following Abe (1993)[^cite-abe1993], the three regimes are
+The factor that sets the relative velocity, $v_\mathrm{rel} = F(\zeta)\,(\rho_m-\rho_s)\,g/\eta_m$, is the melt-solid mobility $F(\zeta)$: the permeability $K(\zeta)$ divided by the porosity $\zeta$ (the melt volume fraction, $\zeta \equiv \phi$).
+Following Abe (1993)[^cite-abe1993], with $a$ the grain size set by `grain_size`, its three regimes are
 
 $$
-K(\zeta) = a^2
+F(\zeta) = \frac{K(\zeta)}{\zeta} = a^2
 \begin{cases}
 \dfrac{2}{9} & \zeta > 0.771462 \quad\text{(Stokes settling)} \\[2mm]
 \dfrac{5}{7}\,\zeta^{4.5} & 0.0769452 \le \zeta \le 0.771462 \quad\text{(Rumpf-Gupte)} \\[2mm]
@@ -100,12 +100,13 @@ K(\zeta) = a^2
 \end{cases}
 $$
 
-Aragog evaluates a $\tanh$-blended composite of these three branches rather than the hard piecewise switch, so that $K(\zeta)$ and its porosity derivative stay continuous for the JAX Jacobian.
-Figure 1 plots the dimensionless factor $F(\zeta) = K(\zeta)/a^2$: the three individual branches (dashed) and the blended composite that Aragog actually evaluates (solid).
+The permeability itself is $K(\zeta) = \zeta\,F(\zeta)$, which recovers the Stokes ($K \propto \zeta$), Rumpf-Gupte ($K \propto \zeta^{5.5}$), and Blake-Kozeny-Carman ($K \propto \zeta^3/(1-\zeta)^2$) forms; the extra power of porosity that separates $K$ from $F$ is the Darcy $1/\zeta$ in the relative velocity.
+Aragog evaluates a $\tanh$-blended composite of the three branches rather than the hard piecewise switch, so that $F(\zeta)$ and its porosity derivative stay continuous for the JAX Jacobian.
+Figure 1 plots the dimensionless mobility $F(\zeta)/a^2$: the three individual branches (dashed) and the blended composite that Aragog actually evaluates (solid).
 
-![Permeability F(porosity)](../figures/vv/fig_04_permeability.png)
+![Melt-solid mobility F(porosity)](../figures/vv/fig_04_permeability.png)
 
-**Figure 1.** The gravitational-separation permeability factor $F(\zeta) = K(\zeta)/a^2$ as a function of porosity. Dashed lines: the three regime branches considered individually, namely Blake-Kozeny-Carman (BKC), Rumpf-Gupte (RG), and Stokes settling, following Abe (1993)[^cite-abe1993]. Solid black: the smooth tanh-blended composite that Aragog actually evaluates, with regime-switch porosities $\zeta_1=0.0769452$ (BKC to RG) and $\zeta_2=0.771462$ (RG to Stokes). (a) Linear axis showing the smooth crossover. (b) Log-log axis showing the BKC regime extending to vanishingly small porosity. The numpy and JAX implementations agree to within float-64 machine epsilon ($\max|\Delta F|=1.1\times 10^{-16}$ in absolute units).
+**Figure 1.** The gravitational-separation mobility $F(\zeta) = K(\zeta)/\zeta$ (the permeability divided by porosity), shown as the dimensionless $F(\zeta)/a^2$ against porosity. Dashed lines: the three regime branches considered individually, namely Blake-Kozeny-Carman (BKC), Rumpf-Gupte (RG), and Stokes settling, following Abe (1993)[^cite-abe1993]. Solid black: the smooth tanh-blended composite that Aragog actually evaluates, with regime-switch porosities $\zeta_1=0.0769452$ (BKC to RG) and $\zeta_2=0.771462$ (RG to Stokes). (a) Linear axis showing the smooth crossover. (b) Log-log axis showing the BKC regime extending to vanishingly small porosity. The numpy and JAX implementations agree to within float-64 machine epsilon ($\max|\Delta F|=1.1\times 10^{-16}$ in absolute units).
 
 ### Phase-boundary smoothing
 

--- a/docs/Explanations/model.md
+++ b/docs/Explanations/model.md
@@ -96,10 +96,10 @@ In the partially molten regime, melt and solid separate vertically by gravity. T
 
 $$
 j_\mathrm{grav} = \rho\,\phi(1-\phi)\,v_\mathrm{rel}\,\mathrm{smth}(\phi),\qquad
-v_\mathrm{rel} = \frac{(\rho_m - \rho_s)\,g\,K(\phi)}{\eta_m},
+v_\mathrm{rel} = \frac{(\rho_m - \rho_s)\,g\,F(\phi)}{\eta_m},
 $$
 
-where $K(\phi)$ is a Stokes-or-Darcy permeability set by the configured `grain_size`, and $\mathrm{smth}(\phi)$ is a smoothing function that vanishes outside the mushy band. Two forms are configurable: the production setting is `phase_smoothing = "tanh"` (SPIDER's two-branch `get_smoothing` of width `matprop_smooth_width = 0.01`); the fallback is `phase_smoothing = "cubic_hermite"` ($16\,g\phi^2(1-g\phi)^2$), kept for residual-EOS-mismatch debugging. The corresponding heat flux is
+where $F(\phi)$ is the melt-solid mobility (the permeability over porosity) set by the configured `grain_size`, and $\mathrm{smth}(\phi)$ is a smoothing function that vanishes outside the mushy band. Two forms are configurable: the production setting is `phase_smoothing = "tanh"` (SPIDER's two-branch `get_smoothing` of width `matprop_smooth_width = 0.01`); the fallback is `phase_smoothing = "cubic_hermite"` ($16\,g\phi^2(1-g\phi)^2$), kept for residual-EOS-mismatch debugging. The corresponding heat flux is
 
 $$
 F_\mathrm{grav} = j_\mathrm{grav}\,L(P),
@@ -236,7 +236,7 @@ Aragog is intended as a fast 1-D mantle thermal evolution model. The core simpli
 | $l$ | m | Mixing length |
 | $\eta$, $\eta_m$ | Pa·s | Dynamic viscosity (mixture, melt) |
 | $j_\mathrm{grav}$ | kg/m²/s | Gravitational-separation mass flux |
-| $K(\phi)$ | m² | Permeability of the partially molten matrix |
+| $F(\phi)$ | m² | Melt-solid mobility (permeability over porosity) |
 | $K_S$ | Pa | Adiabatic bulk modulus (Adams-Williamson) |
 | $\varepsilon$ | -- | Surface emissivity |
 | $\sigma$ | W/m²/K⁴ | Stefan-Boltzmann constant |

--- a/docs/Explanations/model.md
+++ b/docs/Explanations/model.md
@@ -81,7 +81,7 @@ $$
 
 The instability criterion in the entropy formulation is simply $\partial S/\partial r < 0$. The $\max$ form is implemented as a smooth approximation (rather than a hard switch) so that the BDF Jacobian remains continuous through the onset of convection.
 
-The eddy diffusivity $\kappa_h$ is computed from a mixing length $l(r)$ and a regime-dependent velocity scale. The viscous and inviscid limits of Abe (1993) [^cite-abe1993] are blended via a $\tanh$ on the cell Reynolds number around $Re_\mathrm{crit} = 9/8$:
+The eddy diffusivity $\kappa_h$ is computed from a mixing length $l(r)$ and a regime-dependent velocity scale. The viscous and inviscid limits of Abe (1993)[^cite-abe1993] are blended via a $\tanh$ on the cell Reynolds number around $Re_\mathrm{crit} = 9/8$, the critical value Aragog inherits via Abe (1995)[^cite-abe1995] and documented in Bower et al. (2018)[^cite-bower2018] §2.1:
 
 $$
 \kappa_h = l\,\Big[(1-w)\,v_\mathrm{visc} + w\,v_\mathrm{inv}\Big],\qquad
@@ -260,3 +260,5 @@ The formulation maps to the following source modules:
 For the package layout in detail, see [Code architecture](code_architecture.md). For the public API, see the [API reference](../Reference/api/index.md).
 
 [^cite-abe1993]: Yutaka Abe, *[Thermal evolution and chemical differentiation of the terrestrial magma ocean](https://doi.org/10.1029/GM074p0041)*, Geophysical Monograph 74, AGU, 41–54, 1993. [SciX](https://scixplorer.org/abs/1993GMS....74...41A/abstract).
+[^cite-abe1995]: Yutaka Abe, *Basic equations for evolution of partially molten mantle and core*, in Yukutake, T. (ed.), The Earth's Central Part: Its Structure and Dynamics, Terra Sci. Pub. Com., 215–230, 1995.
+[^cite-bower2018]: D. J. Bower, P. Sanan, A. S. Wolf, *[Numerical solution of a non-linear conservation law applicable to the interior dynamics of partially molten planets](https://doi.org/10.1016/j.pepi.2017.11.004)*, Physics of the Earth and Planetary Interiors, 274, 49–62, 2018. [SciX](https://scixplorer.org/abs/2018PEPI..274...49B/abstract).

--- a/docs/Explanations/two_phase_flow.md
+++ b/docs/Explanations/two_phase_flow.md
@@ -61,10 +61,10 @@ The mass flux of melt (positive upward when melt is buoyant) is
 
 $$
 j_\mathrm{grav} = \rho\,\phi(1-\phi)\,v_\mathrm{rel}\,\mathrm{smth}(\phi),\qquad
-v_\mathrm{rel} = \frac{(\rho_\mathrm{liq} - \rho_\mathrm{sol})\,g\,K(\phi)}{\eta_\mathrm{liq}}.
+v_\mathrm{rel} = \frac{(\rho_\mathrm{liq} - \rho_\mathrm{sol})\,g\,F(\phi)}{\eta_\mathrm{liq}}.
 $$
 
-The permeability factor $K(\phi)$ spans three asymptotic regimes (Bower et al. (2018) §2.1):
+The mobility factor $F(\phi)$ (the permeability $K(\phi)$ divided by porosity) spans three asymptotic regimes (Bower et al. (2018) §2.1):
 
 - **Stokes settling** at high $\phi$: melt is the matrix and solid grains settle as isolated spheres, derived from Stokes' law (Bower et al. (2018) Eq. 13a).
 - **Rumpf-Gupte** at intermediate $\phi$: power-law permeability fit to particle-bed measurements (Rumpf & Gupte, 1971, Chem. Ing. Tech. 43, 367)[^cite-rumpfgupte1971].
@@ -72,7 +72,7 @@ The permeability factor $K(\phi)$ spans three asymptotic regimes (Bower et al. (
 
 The three-regime $\zeta_\mathrm{grav}(\phi)$ formulation that Aragog and SPIDER use is consolidated in Abe (1995)[^cite-abe1995] and reviewed in Bower et al. (2018) §2.1 Eqs. 13a-c, where the regime transitions are density-ratio-dependent: $\rho_\mathrm{liq}/(11.993\,\rho_\mathrm{sol} + \rho_\mathrm{liq})$ for BKC-to-RG and $\rho_\mathrm{liq}/(0.29624\,\rho_\mathrm{sol} + \rho_\mathrm{liq})$ for RG-to-Stokes.
 Aragog hard-codes the equal-density-ratio limits ($\rho_\mathrm{sol} = \rho_\mathrm{liq}$) of these expressions, $\zeta_1 = 0.0769452$ (BKC to RG) and $\zeta_2 = 0.771462$ (RG to Stokes), and blends through them with a tanh switch rather than recomputing per radial node.
-The resulting permeability-vs-porosity curve (Figure 1 of [Heat transport](heat_transport.md#permeability-kzeta-across-the-three-abe-regimes)) is JAX-differentiable and shifts the transition location by a few percent in $\phi$ relative to the density-ratio-dependent form.
+The resulting mobility-vs-porosity curve (Figure 1 of [Heat transport](heat_transport.md#melt-solid-mobility-across-the-three-abe-regimes)) is JAX-differentiable and shifts the transition location by a few percent in $\phi$ relative to the density-ratio-dependent form.
 The corresponding heat flux is
 
 $$

--- a/docs/How-to/configuration.md
+++ b/docs/How-to/configuration.md
@@ -227,7 +227,7 @@ Mixed-phase (mushy) parameters and the optional constant-properties analytical m
 | `liquidus` | str | -- | Path to a liquidus reference (legacy T-based) |
 | `phase` | str | -- | Phase label |
 | `phase_transition_width` | -- | -- | Legacy smoothing width |
-| `grain_size` | m | -- | Grain size for the Stokes permeability |
+| `grain_size` | m | `1.0e-3` | Grain size $a$ in the melt-solid mobility $F(\zeta)=K(\zeta)/\zeta$ |
 | `matprop_smooth_width` | -- | 0.0 | SPIDER-parity blending width across phase boundaries |
 | `cp_blend` | str | `"latent"` | `"latent"` (SPIDER parity) or `"linear"` for the mushy $C_p$ rule |
 | `const_properties` | bool | false | Enable the analytic constant-properties path (no EOS tables needed) |

--- a/src/aragog/jax/phase.py
+++ b/src/aragog/jax/phase.py
@@ -537,7 +537,8 @@ def relative_velocity(
 ) -> jax.Array:
     """Melt-solid relative velocity for gravitational separation [m/s].
 
-    Three-regime permeability model (Abe 1993/1995, SPIDER convention):
+    Three-regime mobility model, the permeability over porosity that
+    multiplies delta_rho*g/eta (Abe 1993/1995, SPIDER convention):
     Blake-Kozeny-Carman -> Rumpf-Gupte -> Stokes settling.
     """
     rho_s = eos._lookup_at_phase_boundary('density', P, 'solid')
@@ -562,7 +563,7 @@ def relative_velocity(
     por = jnp.maximum(porosity, 1e-20)
     one_m_por = jnp.maximum(1.0 - porosity, 1e-20)
 
-    # Three permeability regimes
+    # Three mobility regimes (permeability / porosity)
     F_bkc = d**2 * por**2 / (one_m_por**2 * 1000.0)
     F_rg = d**2 * por**4.5 * (5.0 / 7.0)
     F_stokes = d**2 * 2.0 / 9.0

--- a/tools/verification/figures/verify_permeability.py
+++ b/tools/verification/figures/verify_permeability.py
@@ -1,6 +1,6 @@
-"""V&V Figure 4: Three-regime permeability F(porosity).
+"""V&V Figure 4: Three-regime melt-solid mobility F(porosity).
 
-Verifies that the gravitational-separation permeability factor F = K
+Verifies that the gravitational-separation mobility factor F = K/porosity
 (in m^2) implements the Abe (1993, 1995) three-regime model -- Stokes,
 Rumpf-Gupte (RG), and Blake-Kozeny-Carman (BKC) -- with the exact
 critical-porosity tanh blends specified in the Aragog formulation. Both the numpy implementation


### PR DESCRIPTION
## Description
The gravitational-separation section of the heat-transport docs named the three Abe regimes and plotted them, but did not write the piecewise factor out, and where it was mentioned it was called a "permeability". That factor is actually the melt-solid mobility, the permeability divided by porosity: the quantity multiplying (rho_m - rho_s) g / eta in the relative velocity. This writes out the explicit piecewise F(zeta) = K(zeta)/zeta, labels it as the mobility consistently across the heat-transport, model, and two-phase-flow pages and the Figure 1 caption, and adds a note giving the underlying permeability K(zeta) = zeta F(zeta). No linked issue.

## Validation of changes
Settled the permeability-vs-mobility question from the porosity exponents: multiplying each coded branch by zeta recovers the textbook Stokes (proportional to zeta), Rumpf-Gupte (zeta^5.5), and Kozeny-Carman (zeta^3/(1-zeta)^2) permeabilities, so the coded factor is K/zeta; and the solver applies v_rel = F (rho_m - rho_s) g / eta with no explicit 1/zeta, which is the Darcy relative velocity only if F = K/zeta. Built the docs with `zensical build --clean` (23 pre-existing warnings, none on the edited pages), confirmed the cases block renders under KaTeX 0 and the renamed section anchor resolves from two_phase_flow.md, and ran `tests/test_permeability_constants.py` (3 passed) after the source comment edits. Test configuration: macOS, Python 3.12.

## Changes
- `heat_transport.md`: renamed the section to "Melt-solid mobility across the three Abe regimes", wrote the explicit piecewise F(zeta) = K(zeta)/zeta, added the underlying-permeability note, fixed the parent v_rel formula and the Figure 1 caption, and stated zeta == phi.
- `model.md` and `two_phase_flow.md`: relabeled the v_rel factor as the mobility, updated the symbol table and the cross-reference anchor.
- `configuration.md`: filled the `grain_size` default (1.0e-3 m) and noted grain_size = a.
- Citations: the specific implemented equations (the three-regime mobility and the critical Reynolds number Re_crit = 9/8) cite Abe (1995) and Bower et al. (2018) section 2.1 on every page; Abe (1993) is kept for the general mixing-length-for-magma-oceans origin. Footnote definitions were added where newly cited.
- `src/aragog/jax/phase.py` and `tools/verification/figures/verify_permeability.py`: corrected the comment and docstring wording to "mobility" (text only, no logic or values changed).

## Checklist

- [x] I have followed the [contributing guidelines](https://proteus-framework.org/PROTEUS/CONTRIBUTING.html#how-do-i-contribute)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have checked that the tests still pass on my computer
- [x] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required

Documentation change plus comment and docstring text in two source files; no solver logic, values, tests, or dependencies are changed.
