### PR TITLE
Split the docs deploy into build and deploy jobs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,22 +8,29 @@ permissions:
   contents: read
   pages: write
   id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 jobs:
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/configure-pages@v5
       - uses: actions/checkout@v5
+      - uses: actions/configure-pages@v5
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install zensical markdown-include pymdown-extensions mkdocstrings mkdocstrings-python
-      - run: zensical build --clean 
+      - run: zensical build --clean
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - uses: actions/deploy-pages@v4
         id: deployment


### PR DESCRIPTION
## Description

The docs workflow ran the site build, the artifact upload, and the Pages deployment in a single job, so re-running only the failed deploy step re-uploaded the `github-pages` artifact and the deployment then failed because two artifacts of the same name were present. This splits the workflow into a build job that produces the artifact and a deploy job that only publishes it, so a deploy re-run never re-uploads and is safe to retry. It also adds a `pages` concurrency group so overlapping runs queue instead of racing. The build content is unchanged: the same dependencies, the same `zensical build --clean`, and the same site artifact path.

## Validation of changes

Ran `zensical build --clean` locally (macOS, Python 3.x): exit 0, `site/` produced, no new warnings. Confirmed the workflow YAML parses, the build to deploy job graph is correct, the deploy job carries no upload step so a re-run cannot create a second artifact, and the concurrency group is set. Docs content is untouched.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [ ] I have checked that the tests still pass on my computer
- [ ] I have updated the docs, as appropriate
- [ ] I have added tests for these changes, as appropriate
- [ ] I have checked that all dependencies have been updated, as required
